### PR TITLE
Potential fix for code scanning alert no. 61: Unsigned difference expression compared to zero

### DIFF
--- a/opencog/util/lazy_selector.cc
+++ b/opencog/util/lazy_selector.cc
@@ -39,7 +39,7 @@ namespace opencog
 lazy_selector::lazy_selector(unsigned int u, unsigned int l)
     : _u(u), _l(l)
 {
-    OC_ASSERT(u - l > 0, "you cannot select any thing from an empty list");
+    OC_ASSERT(u > l, "you cannot select any thing from an empty list");
 }
 
 bool lazy_selector::empty() const


### PR DESCRIPTION
Potential fix for [https://github.com/drzo/cogutil-v1/security/code-scanning/61](https://github.com/drzo/cogutil-v1/security/code-scanning/61)

To fix the problem, we need to change the comparison from `u - l > 0` to `u > l`. This will correctly check if `u` is greater than `l` without involving any subtraction, thus avoiding the issue of unsigned underflow.

- Change the comparison in the constructor of `lazy_selector` from `u - l > 0` to `u > l`.
- This change should be made in the file `opencog/util/lazy_selector.cc` on line 42.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
